### PR TITLE
Fix/cocktail order logic

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { Box, VStack, Heading, Button, Select } from "@chakra-ui/react";
+import {
+  Box,
+  VStack,
+  Heading,
+  Button,
+  Select,
+  useToast,
+} from "@chakra-ui/react";
 import Back from "@/components/Back";
 import { useState, useEffect } from "react";
 
@@ -8,6 +15,7 @@ export default function Admin() {
   const [availableDrinks, setAvailableDrinks] = useState<string[]>([]);
   const [allDrinks, setAllDrinks] = useState<string[]>([]); // 드롭다운에 표시될 전체 음료 리스트
   const [isLoading, setIsLoading] = useState(true);
+  const toast = useToast(); // toast 훅을 사용
 
   useEffect(() => {
     const fetchDrinks = async () => {
@@ -30,13 +38,20 @@ export default function Admin() {
         ]);
       } catch (error) {
         console.error("Error fetching drinks:", error);
+        toast({
+          title: "에러 발생",
+          description: "음료 정보를 불러오는 데 실패했습니다.",
+          status: "error",
+          duration: 3000,
+          isClosable: true,
+        });
       } finally {
         setIsLoading(false);
       }
     };
 
     fetchDrinks();
-  }, []);
+  }, [toast]);
 
   const handleSaveChanges = async () => {
     try {
@@ -52,10 +67,22 @@ export default function Admin() {
         throw new Error("Failed to save changes.");
       }
 
-      alert("Changes saved successfully!");
+      toast({
+        title: "변경 사항 저장 성공",
+        description: "음료 설정이 성공적으로 저장되었습니다.",
+        status: "success",
+        duration: 3000,
+        isClosable: true,
+      });
     } catch (error) {
       console.error("Error saving changes:", error);
-      alert("Failed to save changes.");
+      toast({
+        title: "저장 실패",
+        description: "변경 사항 저장에 실패했습니다. 다시 시도해 주세요.",
+        status: "error",
+        duration: 3000,
+        isClosable: true,
+      });
     }
   };
 

--- a/components/CustomCocktail.tsx
+++ b/components/CustomCocktail.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { useState } from "react";
-import { Box, VStack, Image, Button, Alert, AlertIcon } from "@chakra-ui/react";
+import { useRouter } from "next/navigation";
+import {
+  Box,
+  VStack,
+  Image,
+  Button,
+  useToast, // useToast 추가
+} from "@chakra-ui/react";
 import IngredientItem from "@/components/IngredientItem";
 
 interface Ingredient {
@@ -20,7 +27,8 @@ export default function CustomCocktail({
       .map((name) => ({ name, amount: 0 }))
   );
 
-  const [orderStatus, setOrderStatus] = useState<string | null>(null); // 주문 상태 관리
+  const router = useRouter();
+  const toast = useToast(); // useToast 사용
 
   const handleIncrement = (index: number) => {
     setIngredients((prev) =>
@@ -44,12 +52,12 @@ export default function CustomCocktail({
 
   const handleOrder = async () => {
     const customCocktailData = {
-      cocktail: "Custom Cocktail", // 커스텀 칵테일 이름
-      name: "커스텀 칵테일", // 사용자 지정 칵테일 이름
+      cocktail: "Custom Cocktail",
+      name: "커스텀 칵테일",
       abv: -1,
       ingredients: ingredients.reduce(
         (acc: { [key: string]: number }, { name, amount }) => {
-          if (amount > 0) acc[name] = amount; // 양이 0보다 큰 재료만 포함
+          if (amount > 0) acc[name] = amount;
           return acc;
         },
         {}
@@ -59,7 +67,13 @@ export default function CustomCocktail({
 
     // 주문할 재료가 없으면 주문 불가
     if (Object.keys(customCocktailData.ingredients).length === 0) {
-      setOrderStatus("재료를 추가해야 주문할 수 있습니다.");
+      toast({
+        title: "주문 실패",
+        description: "재료를 추가해야 주문할 수 있습니다.",
+        status: "error",
+        duration: 3000,
+        isClosable: true,
+      });
       return;
     }
 
@@ -68,13 +82,17 @@ export default function CustomCocktail({
       (sum, amount) => sum + amount,
       0
     );
-
     if (totalAmount > 300) {
-      setOrderStatus("총 용량은 300ml를 초과할 수 없습니다.");
+      toast({
+        title: "주문 실패",
+        description: "총 용량은 300ml를 초과할 수 없습니다.",
+        status: "error",
+        duration: 3000,
+        isClosable: true,
+      });
       return;
     }
 
-    // 큐에 주문을 보냄
     try {
       const response = await fetch("/api/queue", {
         method: "POST",
@@ -85,13 +103,32 @@ export default function CustomCocktail({
       });
 
       if (response.ok) {
-        setOrderStatus("주문이 큐에 추가되었습니다!"); // 성공
+        toast({
+          title: "주문 성공",
+          description: "주문이 성공적으로 큐에 추가되었습니다!",
+          status: "success",
+          duration: 3000,
+          isClosable: true,
+        });
+        router.push("/queue");
       } else {
-        setOrderStatus("주문 실패! 다시 시도해 주세요."); // 실패
+        toast({
+          title: "주문 실패",
+          description: "주문에 실패했습니다. 다시 시도해 주세요.",
+          status: "error",
+          duration: 3000,
+          isClosable: true,
+        });
       }
     } catch (error) {
       console.error("주문 처리 중 에러 발생:", error);
-      setOrderStatus("주문 처리 중 에러가 발생했습니다."); // 오류 처리
+      toast({
+        title: "주문 에러",
+        description: "주문 처리 중 에러가 발생했습니다.",
+        status: "error",
+        duration: 3000,
+        isClosable: true,
+      });
     }
   };
 
@@ -105,20 +142,6 @@ export default function CustomCocktail({
       boxShadow="0 4px 16px rgba(0, 0, 0, 0.1)"
     >
       <VStack spacing="16px">
-        {/* 주문 상태 알림 */}
-        {orderStatus && (
-          <Alert
-            status={
-              orderStatus.includes("실패") || orderStatus.includes("에러")
-                ? "error"
-                : "success"
-            }
-          >
-            <AlertIcon />
-            {orderStatus}
-          </Alert>
-        )}
-
         <Image
           src="/Cocktail.png"
           alt="Custom Cocktail"
@@ -144,7 +167,7 @@ export default function CustomCocktail({
           color="white"
           _hover={{ backgroundColor: "#2C2C69" }}
           _active={{ backgroundColor: "#1E1E54" }}
-          onClick={handleOrder} // 주문하기 클릭 핸들러
+          onClick={handleOrder}
         >
           주문하기
         </Button>

--- a/components/CustomCocktail.tsx
+++ b/components/CustomCocktail.tsx
@@ -26,7 +26,7 @@ export default function CustomCocktail({
     setIngredients((prev) =>
       prev.map((ingredient, i) =>
         i === index
-          ? { ...ingredient, amount: ingredient.amount + 10 }
+          ? { ...ingredient, amount: ingredient.amount + 30 }
           : ingredient
       )
     );
@@ -36,7 +36,7 @@ export default function CustomCocktail({
     setIngredients((prev) =>
       prev.map((ingredient, i) =>
         i === index && ingredient.amount > 0
-          ? { ...ingredient, amount: ingredient.amount - 10 }
+          ? { ...ingredient, amount: ingredient.amount - 30 }
           : ingredient
       )
     );
@@ -46,7 +46,7 @@ export default function CustomCocktail({
     const customCocktailData = {
       cocktail: "Custom Cocktail", // 커스텀 칵테일 이름
       name: "커스텀 칵테일", // 사용자 지정 칵테일 이름
-      abv: 0,
+      abv: -1,
       ingredients: ingredients.reduce(
         (acc: { [key: string]: number }, { name, amount }) => {
           if (amount > 0) acc[name] = amount; // 양이 0보다 큰 재료만 포함
@@ -56,6 +56,23 @@ export default function CustomCocktail({
       ),
       imageSrc: "none",
     };
+
+    // 주문할 재료가 없으면 주문 불가
+    if (Object.keys(customCocktailData.ingredients).length === 0) {
+      setOrderStatus("재료를 추가해야 주문할 수 있습니다.");
+      return;
+    }
+
+    // 300ml 이상 주문할 수 없음
+    const totalAmount = Object.values(customCocktailData.ingredients).reduce(
+      (sum, amount) => sum + amount,
+      0
+    );
+
+    if (totalAmount > 300) {
+      setOrderStatus("총 용량은 300ml를 초과할 수 없습니다.");
+      return;
+    }
 
     // 큐에 주문을 보냄
     try {

--- a/components/Menu.tsx
+++ b/components/Menu.tsx
@@ -30,9 +30,11 @@ const Menu = ({ imageSrc, name, description, abv }: MenuProps) => {
         <Text fontSize="18px" fontWeight="semibold" lineHeight="1.2">
           {name}
         </Text>
-        <Text fontSize="13px" color="#7174BE">
-          ABV {abv}%
-        </Text>
+        {abv !== -1 && (
+          <Text fontSize="13px" color="#7174BE">
+            ABV {abv}%
+          </Text>
+        )}
       </VStack>
     </Box>
   );

--- a/components/overlay/CompleteOverlay.tsx
+++ b/components/overlay/CompleteOverlay.tsx
@@ -1,7 +1,15 @@
 import { Text, Button, VStack } from "@chakra-ui/react";
+import { useRouter } from "next/navigation";
 import OverlayContainer from "./OverlayContainer";
 
 export default function CompleteOverlay({ onClose }: { onClose: () => void }) {
+  const router = useRouter();
+
+  const handleClose = () => {
+    onClose();
+    router.push("/queue");
+  };
+
   return (
     <OverlayContainer>
       <VStack flex="1" spacing="16px" align="stretch">
@@ -22,7 +30,7 @@ export default function CompleteOverlay({ onClose }: { onClose: () => void }) {
           height="50px"
           variant="outline"
           color="#2A2A2A"
-          onClick={onClose}
+          onClick={handleClose}
         >
           닫기
         </Button>

--- a/package-lock.json
+++ b/package-lock.json
@@ -219,7 +219,6 @@
       "version": "2.10.4",
       "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-2.10.4.tgz",
       "integrity": "sha512-XyRWnuZ1Uw7Mlj5pKUGO5/WhnIHP/EOrpy6lGZC1yWlkd0eIfIpYMZ1ALTZx4KPEdbBaes48dgiMT2ROCqLhkA==",
-      "license": "MIT",
       "dependencies": {
         "@chakra-ui/hooks": "2.4.3",
         "@chakra-ui/styled-system": "2.12.1",


### PR DESCRIPTION
## 작업 내용
- 커스텀 칵테일 30ml 단위로 수정할 수 있게 변경
- 0ml짜리 커스텀 칵테일 주문도 받아짐, 커스텀 칵테일 용량 0ml초과, 300ml 이하로 제한 로직 추가
- 커스텀 칵테일이면 abv 표시 안하도록 수정
- 주문 성공시 /queue 페이지로 리다이렉트
- admin, custom 토스트 사용

## 기타
- https://github.com/jamie2779/cocktail-web/pull/6 코드 리뷰에 대한 후속 수정

## 체크리스트
- [x] 주요 기능이 정상적으로 동작함
- [x] 코드에 불필요한 주석이나 디버깅 흔적이 없음
- [x] 기존 코드와 호환성에 문제가 없음
- [x] 필요한 문서를 업데이트 함
- [x] 민감한 정보(api키 등)가 포함되어 있지 않음
